### PR TITLE
R# SSR patterns to assist in migrating from obsolete ShouldBeOfType<T>

### DIFF
--- a/Misc/Migrate_ShouldBeOfType.DotSettings
+++ b/Misc/Migrate_ShouldBeOfType.DotSettings
@@ -1,0 +1,53 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/Comment/@EntryValue">Migrate ShouldBeOfType&lt;T&gt; to ShouldBeOfExactType&lt;T&gt;</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/CustomPatternPlaceholder/=expression/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/CustomPatternPlaceholder/=expression/Properties/=ExactType/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/CustomPatternPlaceholder/=expression/Properties/=ExpressionType/@EntryIndexedValue"></s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/CustomPatternPlaceholder/=expression/Type/@EntryValue">ExpressionPlaceholder</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/CustomPatternPlaceholder/=type/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/CustomPatternPlaceholder/=type/Properties/=ExactType/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/CustomPatternPlaceholder/=type/Properties/=Type/@EntryIndexedValue"></s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/CustomPatternPlaceholder/=type/Type/@EntryValue">TypePlaceholder</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/FormatAfterReplace/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/IgnoreBracesInSingleStatementBlocks/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/IgnoreEmptyStatements/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/IgnoreParanthesisInExpressions/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/IsReplacePattern/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/LanguageName/@EntryValue">CSHARP</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/MatchAllMembersWithoutModifiers/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/MatchMethodParameterWithThisRefOut/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/ReplaceComment/@EntryValue">Replace ShouldBeOfType&lt;T&gt; with ShouldBeOfExactType&lt;T&gt;</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/ReplacePattern/@EntryValue">$expression$.ShouldBeOfExactType&lt;$type$&gt;()</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/SearchPattern/@EntryValue">$expression$.ShouldBeOfType&lt;$type$&gt;()</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/Severity/@EntryValue">SUGGESTION</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/SmartMatchAssociativeExpressions/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/TreatPostfixAndPrefixOperatorEquivalent/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/TreatReversedBinaryExpressionsEquivalent/@EntryValue">Never</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=31676C113CF9E14AB622EC3B5D494659/TypePlaceholderMatchesVoid/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/Comment/@EntryValue">Migrate ShouldBeOfType&lt;T&gt; to ShouldBeAssignableTo&lt;T&gt;</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/CustomPatternPlaceholder/=expression/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/CustomPatternPlaceholder/=expression/Properties/=ExactType/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/CustomPatternPlaceholder/=expression/Properties/=ExpressionType/@EntryIndexedValue"></s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/CustomPatternPlaceholder/=expression/Type/@EntryValue">ExpressionPlaceholder</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/CustomPatternPlaceholder/=type/@KeyIndexDefined">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/CustomPatternPlaceholder/=type/Properties/=ExactType/@EntryIndexedValue">False</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/CustomPatternPlaceholder/=type/Properties/=Type/@EntryIndexedValue"></s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/CustomPatternPlaceholder/=type/Type/@EntryValue">TypePlaceholder</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/FormatAfterReplace/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/IgnoreBracesInSingleStatementBlocks/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/IgnoreEmptyStatements/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/IgnoreParanthesisInExpressions/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/IsReplacePattern/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/LanguageName/@EntryValue">CSHARP</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/MatchAllMembersWithoutModifiers/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/MatchMethodParameterWithThisRefOut/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/ReplaceComment/@EntryValue">Replace ShouldBeOfType&lt;T&gt; with ShouldBeAssignableTo&lt;T&gt;</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/ReplacePattern/@EntryValue">$expression$.ShouldBeAssignableTo&lt;$type$&gt;()</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/SearchPattern/@EntryValue">$expression$.ShouldBeOfType&lt;$type$&gt;()</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/Severity/@EntryValue">SUGGESTION</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/SmartMatchAssociativeExpressions/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/TreatPostfixAndPrefixOperatorEquivalent/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/TreatReversedBinaryExpressionsEquivalent/@EntryValue">Never</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=F1CFD876E0B49D4F9F75C2BFBA2FA5CB/TypePlaceholderMatchesVoid/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
The .dotSettings file can be added as a settings layer in ReSharper 8 and offers two Quick Fixes:
1. Replace expression.ShouldBeOfType<T> with expression.ShouldBeOfExactType<T>
2. Replace expression.ShouldBeOfType<T> with expression.ShouldBeAssignableTo<T>

The migrations can be done one by one using Alt-Enter or a whole project at a time by selecting "Find Now" from the Pattern Catalog.
