### PR TITLE
ShouldBeLike can now handle circular references

### DIFF
--- a/Machine.Specifications.Should.Specs/Machine.Specifications.Should.Specs.csproj
+++ b/Machine.Specifications.Should.Specs/Machine.Specifications.Should.Specs.csproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Machine.snk</AssemblyOriginatorKeyFile>	
+    <AssemblyOriginatorKeyFile>..\Machine.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,12 +36,13 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Machine.Specifications" Condition="'$(SignAssembly)'=='false'">
-      <HintPath>..\packages\Machine.Specifications.0.8.1\lib\net20\Machine.Specifications.dll</HintPath>
-    </Reference>
     <Reference Include="Machine.Specifications" Condition="'$(SignAssembly)'=='true'">
       <HintPath>..\packages\Machine.Specifications-Signed.0.8.1\lib\net20\Machine.Specifications.dll</HintPath>
-    </Reference>	
+    </Reference>
+    <Reference Include="Machine.Specifications, Version=0.9.0.0, Culture=neutral, PublicKeyToken=5c474de7a495cff1, processorArchitecture=MSIL">
+      <HintPath>..\packages\Machine.Specifications-Signed.0.9.3\lib\net20\Machine.Specifications.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -78,11 +79,7 @@
   </PropertyGroup>
   <Target Name="AfterBuild">
     <MakeDir Directories="$(SpecsFolder)" />
-    <Exec 
-      Condition="'$(Configuration)' == 'Release' AND '$(SignAssembly)' == 'false'" 
-      Command="$(SolutionDir)\packages\Machine.Specifications.0.8.1\tools\mspec.exe --progress --silent $(TargetPath) --html $(SpecsFolder)$(MSBuildProjectName).html" />
-	<Exec 
-      Condition="'$(Configuration)' == 'Release' AND '$(SignAssembly)' == 'true'" 
-      Command="$(SolutionDir)\packages\Machine.Specifications-Signed.0.8.1\tools\mspec.exe --progress --silent $(TargetPath) --html $(SpecsFolder)$(MSBuildProjectName).html" />
+    <Exec Condition="'$(Configuration)' == 'Release' AND '$(SignAssembly)' == 'false'" Command="$(SolutionDir)\packages\Machine.Specifications.0.8.1\tools\mspec.exe --progress --silent $(TargetPath) --html $(SpecsFolder)$(MSBuildProjectName).html" />
+    <Exec Condition="'$(Configuration)' == 'Release' AND '$(SignAssembly)' == 'true'" Command="$(SolutionDir)\packages\Machine.Specifications-Signed.0.8.1\tools\mspec.exe --progress --silent $(TargetPath) --html $(SpecsFolder)$(MSBuildProjectName).html" />
   </Target>
 </Project>

--- a/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
+++ b/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
@@ -527,6 +527,23 @@ namespace Machine.Specifications.Should.Specs
   But was:  [null]");
         }
 
+        class and_actual_has_circular_reference
+        {
+            Establish ctx = () =>
+            {
+                node1.Next = node1;
+                node2.Next = null;
+            };
+
+            Because of = () => exception = Catch.Exception(() => node1.ShouldBeLike(node2));
+
+            It should_throw = () => exception.ShouldBeOfExactType<SpecificationException>();
+
+            It should_contain_message = () => exception.Message.ShouldEqual(@"""Next"":
+  Expected: [null]
+  But was:  Machine.Specifications.Should.Specs.when_node_with_circular_references+Node");
+        }
+
         class and_the_object_graph_is_similar
         {
             Establish ctx = () =>

--- a/Machine.Specifications.Should.Specs/packages.config
+++ b/Machine.Specifications.Should.Specs/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitFlowVersionTask" version="0.14.0" targetFramework="net35" />
-  <package id="Machine.Specifications" version="0.8.1" targetFramework="net35" />
-  <package id="Machine.Specifications-Signed" version="0.8.1" targetFramework="net35" />
+  <package id="Machine.Specifications" version="0.9.3" targetFramework="net35" />
+  <package id="Machine.Specifications-Signed" version="0.9.3" targetFramework="net35" />
 </packages>

--- a/Machine.Specifications.Should/Machine.Specifications.Should.csproj
+++ b/Machine.Specifications.Should/Machine.Specifications.Should.csproj
@@ -33,12 +33,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Machine.Specifications" Condition="'$(SignAssembly)'=='false'">
-      <HintPath>..\packages\Machine.Specifications.0.8.1\lib\net20\Machine.Specifications.dll</HintPath>
-    </Reference>
     <Reference Include="Machine.Specifications" Condition="'$(SignAssembly)'=='true'">
       <HintPath>..\packages\Machine.Specifications-Signed.0.8.1\lib\net20\Machine.Specifications.dll</HintPath>
-    </Reference>	
+    </Reference>
+    <Reference Include="Machine.Specifications, Version=0.9.0.0, Culture=neutral, PublicKeyToken=5c474de7a495cff1, processorArchitecture=MSIL">
+      <HintPath>..\packages\Machine.Specifications-Signed.0.9.3\lib\net20\Machine.Specifications.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Obsolete">
       <HintPath>..\packages\Obsolete.Fody.3.1.0.0\Lib\NET35\Obsolete.dll</HintPath>
       <Private>False</Private>

--- a/Machine.Specifications.Should/packages.config
+++ b/Machine.Specifications.Should/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Fody" version="1.23.2" targetFramework="net35" developmentDependency="true" />
   <package id="GitFlowVersionTask" version="0.14.0" targetFramework="net35" />
-  <package id="Machine.Specifications" version="0.8.1" targetFramework="net35" />
-  <package id="Machine.Specifications-Signed" version="0.8.1" targetFramework="net35" />
+  <package id="Machine.Specifications" version="0.9.3" targetFramework="net35" />
+  <package id="Machine.Specifications-Signed" version="0.9.3" targetFramework="net35" />
   <package id="Obsolete.Fody" version="3.1.0.0" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,7 @@
+Machine.Specifications.Should 0.7.3
+-----------------------------
+- ShouldBeLike can now handle circular references
+
 Machine.Specifications.Should 0.7.2
 -----------------------------
 - Fixed typos in obsoletion message


### PR DESCRIPTION
This pull request fixes #10 by detecting circular references. Already checked objects (objects with the same reference) are not checked again.