### PR TITLE
ShouldBeLike can now handle circular references

### DIFF
--- a/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
+++ b/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
@@ -527,6 +527,23 @@ namespace Machine.Specifications.Should.Specs
   But was:  [null]");
         }
 
+        class and_actual_has_circular_reference
+        {
+            Establish ctx = () =>
+            {
+                actualNode.Next = actualNode;
+                expectedNode.Next = null;
+            };
+
+            Because of = () => exception = Catch.Exception(() => actualNode.ShouldBeLike(expectedNode));
+
+            It should_throw = () => exception.ShouldBeOfExactType<SpecificationException>();
+
+            It should_contain_message = () => exception.Message.ShouldEqual(@"""Next"":
+  Expected: [null]
+  But was:  Machine.Specifications.Should.Specs.when_node_with_circular_references+Node");
+        }
+
         class and_the_object_graph_is_similar
         {
             Establish ctx = () =>

--- a/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
+++ b/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
@@ -593,6 +593,30 @@ namespace Machine.Specifications.Should.Specs
         }
     }
 
+    [Subject(typeof (ShouldExtensionMethods))]
+    public class when_node_with_inner_static_node
+    {
+        class Node
+        {
+            public string Field;
+            public static readonly Node Inner = new Node();
+        }
+
+        static Exception exception;
+        static Node actualNode;
+        static Node expectedNode;
+
+        Establish ctx = () =>
+        {
+            actualNode = new Node();
+            expectedNode = new Node();
+        };
+
+        Because of = () => exception = Catch.Exception(() => actualNode.ShouldBeLike(expectedNode));
+
+        It should_not_throw = () => exception.ShouldBeNull();
+    }
+
     [Subject(typeof(ShouldExtensionMethods))]
     class when_complex_type_with_circular_references_are_in_collection
     {

--- a/Machine.Specifications.Should/ShouldExtensionMethods.cs
+++ b/Machine.Specifications.Should/ShouldExtensionMethods.cs
@@ -649,7 +649,8 @@ entire list: {1}",
 
         public static void ShouldBeLike(this object obj, object expected)
         {
-            var exceptions = ShouldBeLikeInternal(obj, expected, "").ToArray();
+
+            var exceptions = ShouldBeLikeInternal(obj, expected, "", new List<object>()).ToArray();
 
             if (exceptions.Any())
             {
@@ -657,8 +658,16 @@ entire list: {1}",
             }
         }
 
-        static IEnumerable<SpecificationException> ShouldBeLikeInternal(object obj, object expected, string nodeName)
+        static IEnumerable<SpecificationException> ShouldBeLikeInternal(object obj, object expected, string nodeName, List<object> visited)
         {
+            if (IsReferenceTypeNotNullOrString(obj) && IsReferenceTypeNotNullOrString(expected))
+            {
+                if (visited.Any(o => ReferenceEquals(o, expected)))
+                    return Enumerable.Empty<SpecificationException>();
+
+                visited.Add(expected);
+            }
+
             ObjectGraphHelper.INode expectedNode = null;
             var nodeType = typeof(ObjectGraphHelper.LiteralNode);
 
@@ -709,7 +718,7 @@ entire list: {1}",
                 return Enumerable.Range(0, expectedCount)
                     .SelectMany(i => ShouldBeLikeInternal(Enumerable.ElementAt<Func<object>>(actualValues, i)(),
                         Enumerable.ElementAt<Func<object>>(expectedValues, i)(),
-                        string.Format("{0}[{1}]", nodeName, i)));
+                        string.Format("{0}[{1}]", nodeName, i), visited));
             }
             else if (nodeType == typeof(ObjectGraphHelper.KeyValueNode))
             {
@@ -734,13 +743,18 @@ entire list: {1}",
                             return new[] { NewException(string.Format("{{0}}:{0}{1}", Environment.NewLine, errorMessage), fullNodeName) };
                         }
 
-                        return ShouldBeLikeInternal(actualKeyValue.ValueGetter(), kv.ValueGetter(), fullNodeName);
+                        return ShouldBeLikeInternal(actualKeyValue.ValueGetter(), kv.ValueGetter(), fullNodeName, visited);
                     });
             }
             else
             {
                 throw new InvalidOperationException("Unknown node type");
             }
+        }
+
+        private static bool IsReferenceTypeNotNullOrString(object obj)
+        {
+            return obj != null && obj.GetType().IsClass && !(obj is string);
         }
     }
 }

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,7 @@
+Machine.Specifications.Should 0.8.0
+-----------------------------
+- ShouldBeLike can now handle circular references
+
 Machine.Specifications.Should 0.7.2
 -----------------------------
 - Fixed typos in obsoletion message


### PR DESCRIPTION
This pull request fixes #10 by detecting circular references. Already checked objects (objects with the same reference) are not checked again.