### PR TITLE
ShouldEqual should work for different types

### DIFF
--- a/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
+++ b/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
@@ -73,6 +73,21 @@ namespace Machine.Specifications.Should.Specs
 
             It should_throw = () => Exception.ShouldBeOfExactType<SpecificationException>();
         }
+
+        public class with_different_types
+        {
+            public class and_object_should_equal_integer
+            {
+                Because of = () => Exception = Catch.Exception(() => new object().ShouldEqual(5));
+                It should_throw_specificationException = () => Exception.ShouldBeOfExactType<SpecificationException>();
+            }
+
+            public class and_integer_should_equal_object
+            {
+                Because of = () => Exception = Catch.Exception(() => 5.ShouldEqual(new object()));
+                It should_throw_specificationException = () => Exception.ShouldBeOfExactType<SpecificationException>();
+            }
+        }
     }
 
     [Subject(typeof(ShouldExtensionMethods))]

--- a/Machine.Specifications.Should/ComparerStrategies/ComparableComparer.cs
+++ b/Machine.Specifications.Should/ComparerStrategies/ComparableComparer.cs
@@ -17,9 +17,12 @@ namespace Machine.Specifications.ComparerStrategies
 
             if (comparable2 != null)
             {
+                if (!(comparable2.GetType().IsInstanceOfType(y)))
+                {
+                    return new NoResult();
+                }
                 return new ComparisionResult(comparable2.CompareTo(y));
             }
-
             return new NoResult();
         }
     }

--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,6 @@
 Machine.Specifications.Should 0.8.0
 -----------------------------
-- ShouldBeLike can now handle circular references
+- ShouldBeLike can now handle circular references (#10)
 - Fixed ShouldEqual exceptions for different types (#8)
 
 Machine.Specifications.Should 0.7.2

--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,7 @@
 Machine.Specifications.Should 0.8.0
 -----------------------------
 - ShouldBeLike can now handle circular references
+- Fixed ShouldEqual exceptions for different types (#8)
 
 Machine.Specifications.Should 0.7.2
 -----------------------------


### PR DESCRIPTION
fixes #8: ShouldEqual should work for different types (expected type other than actual)