### PR TITLE
Bug in ShouldBeLikeInternal()'s loop detection

### DIFF
--- a/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
+++ b/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
@@ -74,6 +74,35 @@ namespace Machine.Specifications.Should.Specs
             It should_throw = () => Exception.ShouldBeOfExactType<SpecificationException>();
         }
 
+        public class with_using_object_multiple_times_in_expected_object_graph
+        {
+            // Regression test for issue 17: ShouldBeLikeInternal() must mark <actual,expected> as visisted instead of simply marking <expected>.
+
+            Establish ctx = () =>
+            {
+                _a = new Dummy { Prop = "a" };
+                _b = new Dummy { Prop = "b" };
+            };
+
+            Because of = () => { Exception = Catch.Exception(() => new { A = _a, B = _b  }.ShouldBeLike(new { A = _a, B = _a  })); };
+      
+            It should_contain_message = () => Exception.Message.ShouldEqual(@"""B.Prop"":
+  String lengths are both 1. Strings differ at index 0.
+  Expected: ""a""
+  But was:  ""b""
+  -----------^");
+
+            It should_throw = () => Exception.ShouldBeOfExactType<SpecificationException>();
+
+            static Dummy _a;
+            static Dummy _b;
+
+            class Dummy
+            {
+                public string Prop { get; set; }
+            }
+        }
+
         public class with_different_types
         {
             public class and_object_should_equal_integer

--- a/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
+++ b/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
@@ -137,6 +137,36 @@ namespace Machine.Specifications.Should.Specs
 
             It should_throw = () => Exception.ShouldBeOfExactType<SpecificationException>();
         }
+
+        public class with_using_object_multiple_times_in_expected_value
+        {
+            // Regression test for issue 17: ShouldBeLikeInternal() must mark <actual,expected> as visisted instead of simply marking <expected>.
+
+            Establish ctx = () =>
+            {
+                _a = new Dummy { Prop = "a" };
+                _b = new Dummy { Prop = "b" };
+                _array = new[] { _a, _b };
+            };
+
+            Because of = () => { Exception = Catch.Exception(() => _array.ShouldBeLike(new[] { _a, _a })); };
+
+            It should_contain_message = () => Exception.Message.ShouldEqual(@"""[1].Prop"":
+  String lengths are both 1. Strings differ at index 0.
+  Expected: ""a""
+  But was:  ""b""
+  -----------^");
+
+            It should_throw = () => Exception.ShouldBeOfExactType<SpecificationException>();
+
+            static Dummy _a;
+            static Dummy _b;
+
+            class Dummy
+            {
+                public string Prop { get; set; }
+            }
+        }
     }
 
     [Subject(typeof(ShouldExtensionMethods))]

--- a/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
+++ b/Machine.Specifications.Should.Specs/ShouldBeLikeSpecs.cs
@@ -138,7 +138,7 @@ namespace Machine.Specifications.Should.Specs
             It should_throw = () => Exception.ShouldBeOfExactType<SpecificationException>();
         }
 
-        public class with_using_object_multiple_times_in_expected_value
+        public class with_using_object_multiple_times_in_expected_array
         {
             // Regression test for issue 17: ShouldBeLikeInternal() must mark <actual,expected> as visisted instead of simply marking <expected>.
 

--- a/Machine.Specifications.Should/Machine.Specifications.Should.csproj
+++ b/Machine.Specifications.Should/Machine.Specifications.Should.csproj
@@ -13,7 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Machine.snk</AssemblyOriginatorKeyFile>
-    <NuGetPackageImportStamp>428778d0</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -79,12 +80,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\GitFlowVersionTask.0.14.0\Build\GitFlowVersionTask.targets" Condition="Exists('..\packages\GitFlowVersionTask.0.14.0\Build\GitFlowVersionTask.targets')" />
-  <Import Project="..\packages\Fody.1.23.2\build\Fody.targets" Condition="Exists('..\packages\Fody.1.23.2\build\Fody.targets')" />
+  <Import Project="..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.1.23.2\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.23.2\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Machine.Specifications.Should/ShouldExtensionMethods.cs
+++ b/Machine.Specifications.Should/ShouldExtensionMethods.cs
@@ -623,6 +623,8 @@ entire list: {1}",
 
         static IEnumerable<SpecificationException> ShouldBeLikeInternal(object obj, object expected, string nodeName, HashSet<ReferentialEqualityTuple> visited)
         {
+            // Stop at already checked <actual,expected>-pairs to prevent infinite loops (cycles in object graphs). Additionally
+            // this also avoids re-equality-evaluation for already compared pairs.
             var objExpectedTuple = new ReferentialEqualityTuple(obj, expected);
             if (visited.Contains(objExpectedTuple))
                 return Enumerable.Empty<SpecificationException>();

--- a/Machine.Specifications.Should/ShouldExtensionMethods.cs
+++ b/Machine.Specifications.Should/ShouldExtensionMethods.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 using Machine.Specifications.Annotations;
@@ -734,7 +735,7 @@ entire list: {1}",
 
             public override int GetHashCode()
             {
-                return Obj.GetHashCode() * Expected.GetHashCode();
+                return RuntimeHelpers.GetHashCode (Obj) * RuntimeHelpers.GetHashCode (Expected);
             }
 
             public override bool Equals(object other)

--- a/Machine.Specifications.Should/ShouldExtensionMethods.cs
+++ b/Machine.Specifications.Should/ShouldExtensionMethods.cs
@@ -94,44 +94,6 @@ namespace Machine.Specifications
             return expected;
         }
 
-        [ObsoleteEx(Message = "This method behaved like `ShouldBeAssignableTo` which is misleading. For exact type comparison use `ShouldBeOfExactType`, for assignability verification use `ShouldBeAssignableTo`. Redesigned because of #171.", RemoveInVersion = "0.9", TreatAsErrorFromVersion = "0.8")]
-        public static void ShouldBeOfType(this object actual, Type expected)
-        {
-            if (actual == null)
-            {
-                throw new SpecificationException(string.Format("Should be of type {0} but is [null]", expected));
-            }
-
-            if (!expected.IsAssignableFrom(actual.GetType()))
-            {
-                throw new SpecificationException(string.Format("Should be of type {0} but is of type {1}",
-                    expected,
-                    actual.GetType()));
-            }
-        }
-
-        [ObsoleteEx(Message = "This method behaved like `ShouldBeAssignableTo` which is misleading. For exact type comparison use `ShouldBeOfExactType`, for assignability verification use `ShouldBeAssignableTo`. Redesigned because of #171.", RemoveInVersion = "0.9", TreatAsErrorFromVersion = "0.8")]
-        public static void ShouldBeOfType<T>(this object actual)
-        {
-            actual.ShouldBeOfType(typeof(T));
-        }
-
-        [ObsoleteEx(Message = "This method behaved like `ShouldBeAssignableTo` which is misleading. For exact type comparison use `ShouldBeOfExactType`, for assignability verification use `ShouldBeAssignableTo`. Redesigned because of #171.", RemoveInVersion = "0.9", TreatAsErrorFromVersion = "0.8")]
-        public static void ShouldBe(this object actual, Type expected)
-        {
-            actual.ShouldBeOfType(expected);
-        }
-
-        [ObsoleteEx(Message = "This method should no longer be used. Redesigned because of #171. See replacement.", RemoveInVersion = "0.9", TreatAsErrorFromVersion = "0.8", Replacement = "ShouldNotBeOfExactType")]
-        public static void ShouldNotBeOfType(this object actual, Type expected)
-        {
-            if (actual.GetType() == expected)
-            {
-                throw new SpecificationException(string.Format("Should not be of type {0} but is of type {1}", expected,
-                    actual.GetType()));
-            }
-        }
-
         public static void ShouldBeOfExactType(this object actual, Type expected)
         {
             if (actual == null)
@@ -643,7 +605,7 @@ entire list: {1}",
             var exception = Catch.Exception(method);
 
             ShouldNotBeNull(exception);
-            ShouldBeOfType(exception, exceptionType);
+            ShouldBeAssignableTo(exception, exceptionType);
             return exception;
         }
 

--- a/Machine.Specifications.Should/ShouldExtensionMethods.cs
+++ b/Machine.Specifications.Should/ShouldExtensionMethods.cs
@@ -612,7 +612,7 @@ entire list: {1}",
         public static void ShouldBeLike(this object obj, object expected)
         {
 
-            var exceptions = ShouldBeLikeInternal(obj, expected, "", new List<object>()).ToArray();
+            var exceptions = ShouldBeLikeInternal(obj, expected, "", new HashSet<object>()).ToArray();
 
             if (exceptions.Any())
             {
@@ -620,11 +620,11 @@ entire list: {1}",
             }
         }
 
-        static IEnumerable<SpecificationException> ShouldBeLikeInternal(object obj, object expected, string nodeName, List<object> visited)
+        static IEnumerable<SpecificationException> ShouldBeLikeInternal(object obj, object expected, string nodeName, HashSet<object> visited)
         {
             if (IsReferenceTypeNotNullOrString(obj) && IsReferenceTypeNotNullOrString(expected))
             {
-                if (visited.Any(o => ReferenceEquals(o, expected)))
+                if (visited.Contains(expected))
                     return Enumerable.Empty<SpecificationException>();
 
                 visited.Add(expected);

--- a/Machine.Specifications.Should/ShouldExtensionMethods.cs
+++ b/Machine.Specifications.Should/ShouldExtensionMethods.cs
@@ -626,8 +626,8 @@ entire list: {1}",
             var objExpectedTuple = new ReferentialEqualityTuple(obj, expected);
             if (visited.Contains(objExpectedTuple))
                 return Enumerable.Empty<SpecificationException>();
-
-            visited.Add(objExpectedTuple);
+            else
+                visited.Add(objExpectedTuple);
 
             ObjectGraphHelper.INode expectedNode = null;
             var nodeType = typeof(ObjectGraphHelper.LiteralNode);

--- a/Machine.Specifications.Should/ShouldExtensionMethods.cs
+++ b/Machine.Specifications.Should/ShouldExtensionMethods.cs
@@ -612,7 +612,7 @@ entire list: {1}",
         public static void ShouldBeLike(this object obj, object expected)
         {
 
-            var exceptions = ShouldBeLikeInternal(obj, expected, "", new HashSet<SimpleTuple>()).ToArray();
+            var exceptions = ShouldBeLikeInternal(obj, expected, "", new HashSet<ReferentialEqualityTuple>()).ToArray();
 
             if (exceptions.Any())
             {
@@ -620,11 +620,11 @@ entire list: {1}",
             }
         }
 
-        static IEnumerable<SpecificationException> ShouldBeLikeInternal(object obj, object expected, string nodeName, HashSet<SimpleTuple> visited)
+        static IEnumerable<SpecificationException> ShouldBeLikeInternal(object obj, object expected, string nodeName, HashSet<ReferentialEqualityTuple> visited)
         {
             if (IsReferenceTypeNotNullOrString(obj) && IsReferenceTypeNotNullOrString(expected))
             {
-                var objExpectedTuple = new SimpleTuple(obj, expected);
+                var objExpectedTuple = new ReferentialEqualityTuple(obj, expected);
                 if (visited.Contains(objExpectedTuple))
                     return Enumerable.Empty<SpecificationException>();
 
@@ -720,13 +720,13 @@ entire list: {1}",
             return obj != null && obj.GetType().IsClass && !(obj is string);
         }
 
-        // Required for ShouldBeLikeInternal(), unfortunately we do not have Sytem.Tuple<T1,T2> in .NET < 4.0
-        private class SimpleTuple
+        // DTO for ShouldBeLikeInternal() loop detection's visited cache
+        private class ReferentialEqualityTuple
         {
             private object Obj { get; }
             private object Expected { get; }
 
-            public SimpleTuple(object obj, object expected)
+            public ReferentialEqualityTuple(object obj, object expected)
             {
                 Obj = obj;
                 Expected = expected;

--- a/Machine.Specifications.Should/ShouldExtensionMethods.cs
+++ b/Machine.Specifications.Should/ShouldExtensionMethods.cs
@@ -623,14 +623,11 @@ entire list: {1}",
 
         static IEnumerable<SpecificationException> ShouldBeLikeInternal(object obj, object expected, string nodeName, HashSet<ReferentialEqualityTuple> visited)
         {
-            if (IsReferenceTypeNotNullOrString(obj) && IsReferenceTypeNotNullOrString(expected))
-            {
-                var objExpectedTuple = new ReferentialEqualityTuple(obj, expected);
-                if (visited.Contains(objExpectedTuple))
-                    return Enumerable.Empty<SpecificationException>();
+            var objExpectedTuple = new ReferentialEqualityTuple(obj, expected);
+            if (visited.Contains(objExpectedTuple))
+                return Enumerable.Empty<SpecificationException>();
 
-                visited.Add(objExpectedTuple);
-            }
+            visited.Add(objExpectedTuple);
 
             ObjectGraphHelper.INode expectedNode = null;
             var nodeType = typeof(ObjectGraphHelper.LiteralNode);
@@ -714,11 +711,6 @@ entire list: {1}",
             {
                 throw new InvalidOperationException("Unknown node type");
             }
-        }
-
-        private static bool IsReferenceTypeNotNullOrString(object obj)
-        {
-            return obj != null && obj.GetType().IsClass && !(obj is string);
         }
 
         // DTO for ShouldBeLikeInternal() loop detection's visited cache

--- a/Machine.Specifications.Should/ShouldExtensionMethods.cs
+++ b/Machine.Specifications.Should/ShouldExtensionMethods.cs
@@ -739,10 +739,10 @@ entire list: {1}",
 
             public override bool Equals(object other)
             {
-                if (!(other is SimpleTuple))
-                    return false;
-
-                var otherSimpleTuple = (SimpleTuple) other;
+                var otherSimpleTuple = other as ReferentialEqualityTuple;
+                if (otherSimpleTuple == null)
+                  return false;
+              
                 return ReferenceEquals(Obj, otherSimpleTuple.Obj) && ReferenceEquals(Expected, otherSimpleTuple.Expected);
             }
         }

--- a/Machine.Specifications.Should/packages.config
+++ b/Machine.Specifications.Should/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fody" version="1.23.2" targetFramework="net35" developmentDependency="true" />
+  <package id="Fody" version="1.29.4" targetFramework="net35" developmentDependency="true" />
   <package id="GitFlowVersionTask" version="0.14.0" targetFramework="net35" />
   <package id="Machine.Specifications" version="0.9.3" targetFramework="net35" />
   <package id="Machine.Specifications-Signed" version="0.9.3" targetFramework="net35" />


### PR DESCRIPTION
ShouldBeLikeInternal()'s loop-detection returned when expected object has been marked visited, even if compared to a different actual object.

Added missing spec and fixed the problem.