### PR TITLE
IComparable is for sort order not if two object are equals

### DIFF
--- a/src/Machine.Specifications.Should/ComparerStrategies/ComparerFactory.cs
+++ b/src/Machine.Specifications.Should/ComparerStrategies/ComparerFactory.cs
@@ -10,7 +10,6 @@ namespace Machine.Specifications.ComparerStrategies
              {
                new EnumerableComparer<T>(),
                new GenericTypeComparer<T>(),
-               new ComparableComparer<T>(),
                new EquatableComparer<T>(),
                new TypeComparer<T>()
              };


### PR DESCRIPTION
Hi All,

I think remove `new ComparableComparer<T>()` from Comparers strategy should fix this bug.

https://github.com/machine/machine.specifications/issues/372

Thanks

Libor 